### PR TITLE
Add AWS SDK for Go V2 to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ for developing and managing applications on AWS.
 ## AWS SDKs on GitHub
 * [AWS SDK for C++](https://github.com/aws/aws-sdk-cpp)
 * [AWS CLI](https://github.com/aws/aws-cli)
-* [AWS SDK for Go](https://github.com/aws/aws-sdk-go)
+* Go
+  * [AWS SDK for Go V2](https://github.com/aws/aws-sdk-go-v2)
+  * [AWS SDK for Go](https://github.com/aws/aws-sdk-go)
 * Java
   * [AWS SDK for Java, v2](https://github.com/aws/aws-sdk-java-v2)
   * [AWS SDK for Java](https://github.com/aws/aws-sdk-java) (not recommended for new projects)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ for developing and managing applications on AWS.
 * [AWS SDK for C++](https://github.com/aws/aws-sdk-cpp)
 * [AWS CLI](https://github.com/aws/aws-cli)
 * Go
-  * [AWS SDK for Go V2](https://github.com/aws/aws-sdk-go-v2)
+  * [AWS SDK for Go v2](https://github.com/aws/aws-sdk-go-v2)
   * [AWS SDK for Go](https://github.com/aws/aws-sdk-go)
 * Java
   * [AWS SDK for Java, v2](https://github.com/aws/aws-sdk-java-v2)


### PR DESCRIPTION
Adds a link to the AWS SDK for Go V2 GitHub repository.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
