### PR TITLE
chore: relax stale issue timings

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -33,8 +33,8 @@ jobs:
         closed-for-staleness-label: closed-for-staleness
 
         # Issue timing
-        days-before-stale: 5
-        days-before-close: 2
+        days-before-stale: 10
+        days-before-close: 4
 
         # If you don't want to mark a issue as being ancient based on a
         # threshold of "upvotes", you can set this here. An "upvote" is


### PR DESCRIPTION
We received customer feedback that our stale issue timings are too tight. This doubles what we had previously.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
